### PR TITLE
Ported to 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ apply plugin: 'net.minecraftforge.gradle'
 def build_version = "BUILD_ID"
 def capsule_version = "7.0"
 def minecraft_version = "1.19"
-def jei_version = "9.5.3.143"
-def rei_version = "9.0.475"
-def architectury_version = "5.6.21"
-def cloth_config_version = "7.0.69"
+def jei_version = "11.6.0.1015"
+def rei_version = "9.1.530"
+def architectury_version = "6.3.49"
+def cloth_config_version = "8.2.88"
 
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
@@ -111,11 +111,18 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
     maven {
-        url = "https://dvs1.progwml6.com/files/maven"
+		name 'Crafttweaker/Patchouli/Botania/Immersive Engineering/Gamestages'
+		url 'https://maven.blamejared.com/'
+		content {
+			includeGroup "mezz.jei"
+		}
     }
-    maven {
-        url "https://www.cursemaven.com"
-    }
+    //maven {
+        //url = "https://dvs1.progwml6.com/files/maven"
+    //}
+    //maven {
+        //url "https://www.cursemaven.com"
+    //}
     maven {
         url "https://maven.shedaniel.me"
     }
@@ -125,7 +132,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19-41.0.17'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.2.11'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
@@ -144,11 +151,12 @@ dependencies {
     // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-    implementation fg.deobf("dev.architectury:architectury-forge:5.6.22")
-    implementation fg.deobf("me.shedaniel.cloth:cloth-config-forge:7.0.69")
+    implementation fg.deobf("dev.architectury:architectury-forge:${architectury_version}")
+    implementation fg.deobf("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}")
     compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-api-forge:${rei_version}")
     implementation fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
-    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-default-plugin-forge:${rei_version}")
+    implementation fg.deobf("me.shedaniel:RoughlyEnoughItems-default-plugin-forge:${rei_version}")
+    implementation fg.deobf("me.shedaniel:RoughlyEnoughItems-plugin-compatibilities-forge:${rei_version}")
 
 //    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-forge:${rei_version}"
 //    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-forge:${rei_version}"

--- a/src/main/java/capsule/CapsuleMod.java
+++ b/src/main/java/capsule/CapsuleMod.java
@@ -55,13 +55,14 @@ public class CapsuleMod {
     public static MinecraftServer server = null;
 
     public CapsuleMod() {
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
+
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         CapsuleBlocks.registerBlocks(modEventBus);
         CapsuleItems.registerItems(modEventBus);
         CapsuleRecipes.registerRecipeSerializers(modEventBus);
         CapsuleEnchantments.registerEnchantments(modEventBus);
 
-        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
         MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, CapsuleMod::serverStarting);
         MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, CapsuleMod::serverStopped);
         MinecraftForge.EVENT_BUS.addListener(EventPriority.NORMAL, CapsuleMod::RegisterCommands);

--- a/src/main/java/capsule/StructureSaver.java
+++ b/src/main/java/capsule/StructureSaver.java
@@ -4,7 +4,6 @@ import capsule.items.CapsuleItem;
 import capsule.plugins.securitycraft.SecurityCraftOwnerCheck;
 import capsule.structure.CapsuleTemplate;
 import capsule.structure.CapsuleTemplateManager;
-import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -33,8 +32,8 @@ import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.event.entity.EntityJoinWorldEvent;
-import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
+import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -75,7 +74,7 @@ public class StructureSaver {
     private static boolean preventItemDrop = false;
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public static void handleEntityJoinWorldEvent(final EntityJoinWorldEvent e) {
+    public static void handleEntityJoinWorldEvent(final EntityJoinLevelEvent e) {
         if (preventItemDrop && e.getEntity() instanceof ItemEntity) {
             e.setCanceled(true);
         }

--- a/src/main/java/capsule/blocks/BlockEntityCapture.java
+++ b/src/main/java/capsule/blocks/BlockEntityCapture.java
@@ -44,16 +44,16 @@ public class BlockEntityCapture extends DispenserBlockEntity {
 
     public int getSize() {
         int size = 0;
-        if (this.getTileData().contains("size")) {
-            size = this.getTileData().getInt("size");
+        if (this.getPersistentData().contains("size")) {
+            size = this.getPersistentData().getInt("size");
         }
         return size;
     }
 
     public int getColor() {
         int color = 0;
-        if (this.getTileData().contains("color")) {
-            color = this.getTileData().getInt("color");
+        if (this.getPersistentData().contains("color")) {
+            color = this.getPersistentData().getInt("color");
         }
         return color;
     }

--- a/src/main/java/capsule/blocks/CapsuleBlocks.java
+++ b/src/main/java/capsule/blocks/CapsuleBlocks.java
@@ -17,7 +17,7 @@ public class CapsuleBlocks {
 
     private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, CapsuleMod.MODID);
     private static final DeferredRegister<Item> BLOCKITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, CapsuleMod.MODID);
-    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, CapsuleMod.MODID);
+    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, CapsuleMod.MODID);
 
     public static final RegistryObject<Block> CAPSULE_MARKER = BLOCKS.register("capsulemarker", BlockCapsuleMarker::new);
     public static final RegistryObject<BlockItem> CAPSULE_MARKER_ITEM = BLOCKITEMS.register("capsulemarker", () -> new BlockItem(CAPSULE_MARKER.get(), new Item.Properties().tab(CapsuleMod.tabCapsule)));

--- a/src/main/java/capsule/client/CapsulePreviewHandler.java
+++ b/src/main/java/capsule/client/CapsulePreviewHandler.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientChatEvent;
-import net.minecraftforge.client.event.RenderLevelLastEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -78,14 +78,16 @@ public class CapsulePreviewHandler {
      * Render recall preview when deployed capsule in hand
      */
     @SubscribeEvent
-    public static void onLevelRenderLast(RenderLevelLastEvent event) {
-        Minecraft mc = Minecraft.getInstance();
-        time += 1;
-        if (mc.player != null) {
-            dispatcher = event.getLevelRenderer().getChunkRenderDispatcher();
-            tryPreviewRecall(mc.player.getMainHandItem(), event.getPoseStack());
-            tryPreviewDeploy(mc.player, event.getPartialTick(), mc.player.getMainHandItem(), event.getPoseStack());
-            tryPreviewLinkedInventory(mc.player, mc.player.getMainHandItem(), event.getPoseStack());
+    public static void onLevelRenderLast(RenderLevelStageEvent event) {
+        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_PARTICLES) {
+            Minecraft mc = Minecraft.getInstance();
+            time += 1;
+            if (mc.player != null) {
+                dispatcher = event.getLevelRenderer().getChunkRenderDispatcher();
+                tryPreviewRecall(mc.player.getMainHandItem(), event.getPoseStack());
+                tryPreviewDeploy(mc.player, event.getPartialTick(), mc.player.getMainHandItem(), event.getPoseStack());
+                tryPreviewLinkedInventory(mc.player, mc.player.getMainHandItem(), event.getPoseStack());
+            }
         }
     }
 
@@ -392,10 +394,10 @@ public class CapsulePreviewHandler {
         // remember it's client side only
         for (BlockEntityCapture te : new ArrayList<>(BlockEntityCapture.instances)) {
             if (te.getLevel() == worldIn) {
-                CompoundTag teData = te.getTileData();
+                CompoundTag teData = te.getPersistentData();
                 if (teData.getInt("size") != size || teData.getInt("color") != color) {
-                    te.getTileData().putInt("size", size);
-                    te.getTileData().putInt("color", color);
+                    te.getPersistentData().putInt("size", size);
+                    te.getPersistentData().putInt("color", color);
                     if (te.getBlockState().hasProperty(BlockCapsuleMarker.TRIGGERED)) {
                         worldIn.setBlock(te.getBlockPos(), te.getBlockState().setValue(BlockCapsuleMarker.TRIGGERED, size <= 0), 2);
                     }

--- a/src/main/java/capsule/client/render/CapsuleTemplateRenderer.java
+++ b/src/main/java/capsule/client/render/CapsuleTemplateRenderer.java
@@ -10,6 +10,7 @@ import com.mojang.math.Matrix4f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.LiquidBlockRenderer;
 import net.minecraft.client.renderer.block.ModelBlockRenderer;
 import net.minecraft.client.renderer.block.model.BakedQuad;
@@ -39,6 +40,8 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.BitSetDiscreteVoxelShape;
 import net.minecraft.world.phys.shapes.DiscreteVoxelShape;
+import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraftforge.client.model.data.ModelData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -135,7 +138,7 @@ public class CapsuleTemplateRenderer {
             try {
                 if (state.getRenderShape() == RenderShape.MODEL || state.getRenderShape() == RenderShape.ENTITYBLOCK_ANIMATED) {
                     random.setSeed(Mth.getSeed(targetPos));
-                    blockRenderer.tesselateWithAO(templateWorld, ibakedmodel, state, targetPos, poseStack, bufferSolid, true, random, Mth.getSeed(targetPos), OverlayTexture.NO_OVERLAY, net.minecraftforge.client.model.data.EmptyModelData.INSTANCE);
+                    blockRenderer.tesselateWithAO(templateWorld, ibakedmodel, state, targetPos, poseStack, bufferSolid, true, random, Mth.getSeed(targetPos), OverlayTexture.NO_OVERLAY, ModelData.EMPTY, RenderType.LINES);
                 } else {
                     FluidState ifluidstate = state.getFluidState();
                     if (!ifluidstate.isEmpty()) {
@@ -153,23 +156,24 @@ public class CapsuleTemplateRenderer {
     }
 
     private static void renderFluid(PoseStack matrixStack, BlockPos destOriginPos, BlockAndTintGetter world, VertexConsumer buffer, FluidState ifluidstate) {
-        TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(ifluidstate.getType().getAttributes().getStillTexture());
+        IClientFluidTypeExtensions fluidTypeExtensions = IClientFluidTypeExtensions.of(ifluidstate);
+        try (TextureAtlasSprite sprite = Minecraft.getInstance().getTextureAtlas(InventoryMenu.BLOCK_ATLAS).apply(fluidTypeExtensions.getStillTexture())) {
+            float minU = sprite.getU0();
+            float maxU = Math.min(minU + (sprite.getU1() - minU) * 1, sprite.getU1());
+            float minV = sprite.getV0();
+            float maxV = Math.min(minV + (sprite.getV1() - minV) * 1, sprite.getV1());
+            int waterColor =  fluidTypeExtensions.getTintColor(ifluidstate, world, destOriginPos);
+            float red = (float) (waterColor >> 16 & 255) / 255.0F;
+            float green = (float) (waterColor >> 8 & 255) / 255.0F;
+            float blue = (float) (waterColor & 255) / 255.0F;
 
-        float minU = sprite.getU0();
-        float maxU = Math.min(minU + (sprite.getU1() - minU) * 1, sprite.getU1());
-        float minV = sprite.getV0();
-        float maxV = Math.min(minV + (sprite.getV1() - minV) * 1, sprite.getV1());
-        int waterColor = ifluidstate.getType().getAttributes().getColor(world, destOriginPos);
-        float red = (float) (waterColor >> 16 & 255) / 255.0F;
-        float green = (float) (waterColor >> 8 & 255) / 255.0F;
-        float blue = (float) (waterColor & 255) / 255.0F;
+            Matrix4f matrix = matrixStack.last().pose();
 
-        Matrix4f matrix = matrixStack.last().pose();
-
-        vertex(buffer, maxU, minV, red, green, blue, matrix, 0, 1, 0);
-        vertex(buffer, minU, minV, red, green, blue, matrix, 0, 1, 1);
-        vertex(buffer, minU, maxV, red, green, blue, matrix, 1, 1, 1);
-        vertex(buffer, maxU, maxV, red, green, blue, matrix, 1, 1, 0);
+            vertex(buffer, maxU, minV, red, green, blue, matrix, 0, 1, 0);
+            vertex(buffer, minU, minV, red, green, blue, matrix, 0, 1, 1);
+            vertex(buffer, minU, maxV, red, green, blue, matrix, 1, 1, 1);
+            vertex(buffer, maxU, maxV, red, green, blue, matrix, 1, 1, 0);
+        }
     }
 
     private static void vertex(VertexConsumer buffer, float maxU, float minV, float red, float green,
@@ -186,16 +190,16 @@ public class CapsuleTemplateRenderer {
             float f2;
 
             if (bakedquad.isTinted()) {
-                f = red * 1f;
-                f1 = green * 1f;
-                f2 = blue * 1f;
+                f = red;
+                f1 = green;
+                f2 = blue;
             } else {
                 f = 1f;
                 f1 = 1f;
                 f2 = 1f;
             }
 
-            builder.putBulkData(matrixEntry, bakedquad, f, f1, f2, alpha, combinedLightsIn, combinedOverlayIn);
+            builder.putBulkData(matrixEntry, bakedquad, f, f1, f2, alpha, combinedLightsIn, combinedOverlayIn, false);
         }
     }
 

--- a/src/main/java/capsule/enchantments/CapsuleEnchantments.java
+++ b/src/main/java/capsule/enchantments/CapsuleEnchantments.java
@@ -5,48 +5,26 @@ import capsule.Config;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraft.world.item.enchantment.Enchantment.Rarity;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
-import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.function.Predicate;
 
 public class CapsuleEnchantments {
-
     private static final DeferredRegister<Enchantment> ENCHANTMENTS = DeferredRegister.create(ForgeRegistries.ENCHANTMENTS, CapsuleMod.MODID);
-    public static final RegistryObject<Enchantment> RECALL = ENCHANTMENTS.register("recall", CapsuleEnchantments::CreateRecall);
+    public static final RegistryObject<Enchantment> RECALL = ENCHANTMENTS.register("recall", RecallEnchant::new);
 
-    protected static final Logger LOGGER = LogManager.getLogger(CapsuleEnchantments.class);
-
-    public static final Predicate<Entity> hasRecallEnchant = (Entity entityIn) -> entityIn instanceof ItemEntity && EnchantmentHelper.getItemEnchantmentLevel(CapsuleEnchantments.RECALL.get(), ((ItemEntity) entityIn).getItem()) > 0;
+    public static final Predicate<Entity> hasRecallEnchant = (Entity entityIn) ->
+            entityIn instanceof ItemEntity itemEntity && itemEntity.getItem().getEnchantmentLevel(CapsuleEnchantments.RECALL.get()) > 0;
 
     public static void registerEnchantments(IEventBus eventBus) {
         ENCHANTMENTS.register(eventBus);
     }
 
     public static RecallEnchant CreateRecall() {
-        Rarity enchantRarity = Rarity.RARE;
-        try {
-            enchantRarity = Rarity.valueOf(Config.enchantRarity.get());
-        } catch (Exception e) {
-            LOGGER.warn("Couldn't find the rarity " + Config.enchantRarity.get() + ". Using RARE instead.");
-        }
-
-        EnchantmentCategory recallEnchantTypeEnumValue = null;
-        try {
-            recallEnchantTypeEnumValue = EnchantmentCategory.valueOf(Config.recallEnchantType.get());
-        } catch (IllegalArgumentException ignored) {
-        }
-
-        return new RecallEnchant(// name
-                enchantRarity, // weight (chances to appear)
-                recallEnchantTypeEnumValue // possible targets
-        );
+        return new RecallEnchant();
     }
 }

--- a/src/main/java/capsule/helpers/Blueprint.java
+++ b/src/main/java/capsule/helpers/Blueprint.java
@@ -6,7 +6,6 @@ import capsule.StructureSaver.ItemStackKey;
 import capsule.structure.CapsuleTemplate;
 import capsule.structure.CapsuleTemplateManager;
 import com.google.gson.JsonObject;
-import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -25,8 +24,8 @@ import net.minecraft.world.level.block.state.properties.BedPart;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
-import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fml.ModList;
 import org.apache.commons.lang3.tuple.Triple;
@@ -66,10 +65,9 @@ public class Blueprint {
             } else if (block instanceof FarmBlock) {
                 return new ItemStack(Blocks.DIRT);
 
-            } else if (block instanceof LiquidBlock) {
-                LiquidBlock fblock = (LiquidBlock) block;
+            } else if (block instanceof LiquidBlock fblock) {
                 if (isLiquidSource(state, fblock)) {
-                    ItemStack item = FluidUtil.getFilledBucket(new FluidStack(fblock.getFluid(), FluidAttributes.BUCKET_VOLUME));
+                    ItemStack item = FluidUtil.getFilledBucket(new FluidStack(fblock.getFluid(), FluidType.BUCKET_VOLUME));
                     return item.isEmpty() ? null : item; // return null to indicate error
                 }
                 return ItemStack.EMPTY; //flowing liquid is free
@@ -96,7 +94,7 @@ public class Blueprint {
             }
             return item;
         } catch (Exception e) {
-            // some items requires world to have getItem work, here it produces NullPointerException. fallback to default break state of block.
+            // some items require world to have getItem work, here it produces NullPointerException. fallback to default break state of block.
             return new ItemStack(Item.byBlock(block), 1);
         }
     }

--- a/src/main/java/capsule/helpers/Capsule.java
+++ b/src/main/java/capsule/helpers/Capsule.java
@@ -12,7 +12,6 @@ import capsule.network.CapsuleUndeployNotifToClient;
 import capsule.structure.CapsuleTemplate;
 import capsule.structure.CapsuleTemplateManager;
 import net.minecraft.ChatFormatting;
-import net.minecraft.Util;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
@@ -37,7 +36,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.network.PacketDistributor;
 import org.apache.commons.lang3.text.WordUtils;
@@ -55,25 +54,20 @@ public class Capsule {
     protected static final Logger LOGGER = LogManager.getLogger(Capsule.class);
 
     static public String getMirrorLabel(StructurePlaceSettings placement) {
-        switch (placement.getMirror()) {
-            case FRONT_BACK:
-                return ChatFormatting.STRIKETHROUGH + "[ ]";
-            case LEFT_RIGHT:
-                return "[I]";
-        }
-        return "[ ]";
+        return switch (placement.getMirror()) {
+            case FRONT_BACK -> ChatFormatting.STRIKETHROUGH + "[ ]";
+            case LEFT_RIGHT -> "[I]";
+            default -> "[ ]";
+        };
     }
 
     static public String getRotationLabel(StructurePlaceSettings placement) {
-        switch (placement.getRotation()) {
-            case CLOCKWISE_90:
-                return "90";
-            case CLOCKWISE_180:
-                return "180";
-            case COUNTERCLOCKWISE_90:
-                return "270";
-        }
-        return "0";
+        return switch (placement.getRotation()) {
+            case CLOCKWISE_90 -> "90";
+            case CLOCKWISE_180 -> "180";
+            case COUNTERCLOCKWISE_90 -> "270";
+            default -> "0";
+        };
     }
 
     public static void resentToCapsule(final ItemStack capsule, final ServerLevel world, @Nullable final Player playerIn) {
@@ -256,7 +250,7 @@ public class Capsule {
         }
         // try to provision the materials from linked inventory or player inventory
         IItemHandler inv = CapsuleItem.getSourceInventory(blueprint, world);
-        IItemHandler inv2 = player == null ? null : player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).orElse(null);
+        IItemHandler inv2 = player == null ? null : player.getCapability(ForgeCapabilities.ITEM_HANDLER, null).orElse(null);
         Map<Integer, Integer> inv1SlotQuantityProvisions = recordSlotQuantityProvisions(missingMaterials, inv);
         Map<Integer, Integer> inv2SlotQuantityProvisions = recordSlotQuantityProvisions(missingMaterials, inv2);
 
@@ -277,7 +271,7 @@ public class Capsule {
 
     public static void extractItemOrFluid(IItemHandler inv, Integer slot, Integer qty) {
         ItemStack item = inv.extractItem(slot, qty, false);
-        ItemStack container = net.minecraftforge.common.ForgeHooks.getContainerItem(item);
+        ItemStack container = net.minecraftforge.common.ForgeHooks.getCraftingRemainingItem(item);
         inv.insertItem(slot, container, false);
     }
 

--- a/src/main/java/capsule/loot/StarterLoot.java
+++ b/src/main/java/capsule/loot/StarterLoot.java
@@ -26,12 +26,12 @@ public class StarterLoot {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void playerLogin(PlayerEvent.PlayerLoggedInEvent event) {
-        if (!event.getPlayer().level.isClientSide) {
-            if (StringUtil.isNullOrEmpty(Config.starterMode) || Config.starterTemplatesList == null || Config.starterTemplatesList.size() <= 0) {
+        if (!event.getEntity().level.isClientSide) {
+            if (StringUtil.isNullOrEmpty(Config.starterMode) || Config.starterTemplatesList == null || Config.starterTemplatesList.isEmpty()) {
                 LOGGER.info("Capsule starters are disabled in capsule.cfg. To enable, set starterMode to 'all' or 'random' and set a directory path with structures for starterTemplatesPath.");
                 return;
             }
-            ServerPlayer player = (ServerPlayer) event.getPlayer();
+            ServerPlayer player = (ServerPlayer) event.getEntity();
             CompoundTag playerData = player.getPersistentData();
             CompoundTag data;
             if (!playerData.contains("PlayerPersisted")) {

--- a/src/main/java/capsule/recipes/BlueprintCapsuleRecipe.java
+++ b/src/main/java/capsule/recipes/BlueprintCapsuleRecipe.java
@@ -47,7 +47,7 @@ public class BlueprintCapsuleRecipe implements CraftingRecipe {
 
         for (int i = 0; i < nonnulllist.size(); ++i) {
             ItemStack itemstack = inv.getItem(i);
-            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
+            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getCraftingRemainingItem(itemstack));
             if (itemstack.getItem() instanceof CapsuleItem) {
                 nonnulllist.set(i, itemstack.copy());
             }

--- a/src/main/java/capsule/recipes/ClearCapsuleRecipe.java
+++ b/src/main/java/capsule/recipes/ClearCapsuleRecipe.java
@@ -83,7 +83,7 @@ public class ClearCapsuleRecipe extends CustomRecipe {
 
         for (int i = 0; i < nonnulllist.size(); ++i) {
             ItemStack itemstack = inv.getItem(i);
-            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
+            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getCraftingRemainingItem(itemstack));
             if (itemstack.getItem() instanceof CapsuleItem && !CapsuleItem.hasState(itemstack, DEPLOYED)) {
                 // Copy the capsule and give back a recovery capsule of the previous content
                 ItemStack copy = itemstack.copy();

--- a/src/main/java/capsule/recipes/DyeCapsuleRecipe.java
+++ b/src/main/java/capsule/recipes/DyeCapsuleRecipe.java
@@ -155,7 +155,7 @@ public class DyeCapsuleRecipe extends CustomRecipe {
 
         for (int i = 0; i < nonnulllist.size(); ++i) {
             ItemStack itemstack = inv.getItem(i);
-            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
+            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getCraftingRemainingItem(itemstack));
         }
 
         return nonnulllist;

--- a/src/main/java/capsule/recipes/PrefabsBlueprintAggregatorRecipe.java
+++ b/src/main/java/capsule/recipes/PrefabsBlueprintAggregatorRecipe.java
@@ -146,7 +146,7 @@ public class PrefabsBlueprintAggregatorRecipe extends CustomRecipe {
 
             for (int i = 0; i < nonnulllist.size(); ++i) {
                 ItemStack itemstack = inv.getItem(i);
-                nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
+                nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getCraftingRemainingItem(itemstack));
                 if (itemstack.getItem() instanceof CapsuleItem) {
                     nonnulllist.set(i, itemstack.copy());
                 } else if (i == ingredientOneIndex || i == ingredientTwoIndex || i == ingredientThreeIndex) {
@@ -240,11 +240,10 @@ public class PrefabsBlueprintAggregatorRecipe extends CustomRecipe {
             }
             instance.recipes.clear();
 
-            RecipeSerializer<ShapedRecipe> serializer = ShapedRecipe.Serializer.SHAPED_RECIPE;
             int size = buffer.readInt();
             for (int i = 0; i < size; i++) {
                 ResourceLocation id = new ResourceLocation(buffer.readUtf());
-                ShapedRecipe recipe = serializer.fromNetwork(id, buffer);
+                ShapedRecipe recipe = ShapedRecipe.Serializer.SHAPED_RECIPE.fromNetwork(id, buffer);
                 instance.recipes.add(new PrefabsBlueprintCapsuleRecipe(id, recipe));
             }
 
@@ -253,11 +252,10 @@ public class PrefabsBlueprintAggregatorRecipe extends CustomRecipe {
 
         @Override
         public void toNetwork(FriendlyByteBuf buffer, PrefabsBlueprintAggregatorRecipe recipe) {
-            RecipeSerializer<ShapedRecipe> serializer = ShapedRecipe.Serializer.SHAPED_RECIPE;
             buffer.writeInt(recipe.recipes.size());
             for (PrefabsBlueprintCapsuleRecipe subRecipe : recipe.recipes) {
                 buffer.writeUtf(subRecipe.id.toString());
-                serializer.toNetwork(buffer, subRecipe.recipe);
+                ShapedRecipe.Serializer.SHAPED_RECIPE.toNetwork(buffer, subRecipe.recipe);
             }
         }
     }

--- a/src/main/java/capsule/recipes/RecoveryCapsuleRecipe.java
+++ b/src/main/java/capsule/recipes/RecoveryCapsuleRecipe.java
@@ -31,7 +31,7 @@ public class RecoveryCapsuleRecipe implements CraftingRecipe {
 
         for (int i = 0; i < nonnulllist.size(); ++i) {
             ItemStack itemstack = inv.getItem(i);
-            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getContainerItem(itemstack));
+            nonnulllist.set(i, net.minecraftforge.common.ForgeHooks.getCraftingRemainingItem(itemstack));
             if (itemstack.getItem() instanceof CapsuleItem) {
                 nonnulllist.set(i, itemstack.copy());
             }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[38,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[43,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT License"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,8 @@
 {
   "pack": {
-    "pack_format": 6,
-    "description": "Resources used for Capsule mod"
+    "pack_format": 9,
+    "description": "Resources used for Capsule mod",
+    "forge:resource_pack_format": 9,
+    "forge:data_pack_format": 10
   }
 }


### PR DESCRIPTION
Full port to 1.19.2. This address two issues the previous PR didn't:

* `ForgeHooks.getContainerItem()` replacement is `ForgeHooks.getCraftingRemainingItem()`
* Reworked the way the Recall enchantment uses the two config values. It's not possible to read the config in the registration phase, i.e. while the Recall enchantment is being registed. That causes IllegalStateException to be thrown. Instead, lazily read the two config values when they are needed.
