### PR TITLE
Fix incompatibility with GDLauncher

### DIFF
--- a/src/main/java/capsule/structure/CapsuleTemplateManager.java
+++ b/src/main/java/capsule/structure/CapsuleTemplateManager.java
@@ -160,7 +160,7 @@ public class CapsuleTemplateManager {
             throw new ResourceLocationException("Invalid resource path: " + locationIn);
         } else {
             String ext = locationIn.getPath().endsWith(extIn) ? "" : extIn;
-            Path p = this.pathGenerated.resolve(locationIn.getPath() + ext);
+            Path p = this.pathGenerated.toAbsolutePath().resolve(locationIn.getPath() + ext).normalize();
             if (FileUtil.isPathNormalized(p) && FileUtil.isPathPortable(p)) {
                 return p;
             } else {


### PR DESCRIPTION
GDLauncher uses a relative path to launch modpacks.  This can cause a problem when checking for a normalized portable path.  By starting with the absolute path and normalizing the path, this fixes the crash while not affecting other launchers that utilize an absolute path to the modpack folder.