### PR TITLE
1.20 improvements

### DIFF
--- a/src/main/java/capsule/client/render/CapsuleTemplateRenderer.java
+++ b/src/main/java/capsule/client/render/CapsuleTemplateRenderer.java
@@ -7,7 +7,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.LiquidBlockRenderer;
@@ -55,7 +54,7 @@ public class CapsuleTemplateRenderer {
     public FakeWorld templateWorld = null;
     private boolean isWorldDirty = true;
     private StructurePlaceSettings lastPlacementSettings;
-    private ModelBlockRenderer blockRenderer = new ModelBlockRenderer(BlockColors.createDefault());
+    private ModelBlockRenderer blockRenderer = Minecraft.getInstance().getBlockRenderer().getModelRenderer();
     private LiquidBlockRenderer liquidBlockRenderer = new LiquidBlockRenderer();
     private final RandomSource random = RandomSource.create();
 

--- a/src/main/java/capsule/items/CapsuleItem.java
+++ b/src/main/java/capsule/items/CapsuleItem.java
@@ -190,7 +190,7 @@ public class CapsuleItem extends Item {
 
         if (!hasStructureLink(stack) && !CapsuleItem.hasState(stack, CapsuleState.LINKED)) {
             return Component.translatable("items.capsule.content_empty");
-        } else if (stack.hasTag() && stack.getTag().contains("label") && !"".equals(stack.getTag().getString("label"))) {
+        } else if (stack.hasTag() && stack.getTag().contains("label") && !stack.getTag().getString("label").isEmpty()) {
             return Component.literal("«")
                     .append(Component.literal(stack.getTag().getString("label")).withStyle(ChatFormatting.ITALIC))
                     .append("»");


### PR DESCRIPTION
* Instead of constructing a new `ModelBlockRenderer` use the one that has already been constructed by the current Minecraft instance
* Change `"".equals()` check to an `isEmpty` check since `getString` returns an empty string if the key isn't found